### PR TITLE
Removed `Parse.clientKey` requirement for initializing ParseTwitterUtils.

### DIFF
--- a/ParseTwitterUtils/PFTwitterUtils.m
+++ b/ParseTwitterUtils/PFTwitterUtils.m
@@ -44,7 +44,7 @@ static PFTwitterAuthenticationProvider *authenticationProvider_;
 }
 
 + (void)_assertParseInitialized {
-    PFTWConsistencyAssert([Parse getApplicationId] && [Parse getClientKey],
+    PFTWConsistencyAssert([Parse getApplicationId],
                           @"PFTwitterUtils should be initialized after setting up Parse.");
 }
 


### PR DESCRIPTION
the client key is not a mandatory configuration argument anymore according to the Parse open source server migration guide documentation.

```
clientKey: The client key for your app. (optional)
```

See: https://github.com/ParsePlatform/parse-server/wiki/Parse-Server-Guide
