### PR TITLE
Add support for using `PF_Twitter` without a linking or logging into a Parse account

### DIFF
--- a/ParseTwitterUtils/PF_Twitter.h
+++ b/ParseTwitterUtils/PF_Twitter.h
@@ -22,6 +22,15 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PF_Twitter : NSObject
 
 /**
+ An instance of `PF_Twitter` configured to access device Twitter accounts with Accounts.framework,
+ and remote Twitter accounts - if no accounts are found locally - through a built-in webview.
+
+ After setting `consumerKey` and `consumerSecret`, authorization to Twitter accounts can be requested with
+`authorizeInBackground`, and then revoked with its opposite, `deauthorizeInBackground`.
+ */
+- (instancetype)init;
+
+/**
  Consumer key of the application that is used to authorize with Twitter.
  */
 @property (nullable, nonatomic, copy) NSString *consumerKey;

--- a/ParseTwitterUtils/PF_Twitter.h
+++ b/ParseTwitterUtils/PF_Twitter.h
@@ -22,8 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PF_Twitter : NSObject
 
 /**
- An instance of `PF_Twitter` configured to access device Twitter accounts with Accounts.framework,
- and remote Twitter accounts - if no accounts are found locally - through a built-in webview.
+ Initializes an instance of `PF_Twitter` configured to access device Twitter accounts with Accounts.framework,
+ and remote access to Twitter accounts - and, if no accounts are found locally - through a built-in webview.
 
  After setting `consumerKey` and `consumerSecret`, authorization to Twitter accounts can be requested with
 `authorizeInBackground`, and then revoked with its opposite, `deauthorizeInBackground`.

--- a/ParseTwitterUtils/PF_Twitter.h
+++ b/ParseTwitterUtils/PF_Twitter.h
@@ -69,6 +69,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask *)authorizeInBackground;
 
 /**
+ Invalidates an OAuth token for the current user, if the Twitter user has granted permission to the
+ current application.
+
+ @return The task, that encapsulates the work being done.
+ */
+- (BFTask *)deauthorizeInBackground;
+
+/**
  Displays an auth dialog and populates the authToken, authTokenSecret, userId, and screenName properties
  if the Twitter user grants permission to the application.
 

--- a/ParseTwitterUtils/PF_Twitter.m
+++ b/ParseTwitterUtils/PF_Twitter.m
@@ -100,19 +100,17 @@
 
     return [[self _performDeauthAsync] pftw_continueAsyncWithBlock:^id(BFTask *task) {
         BFTaskCompletionSource *source = [BFTaskCompletionSource taskCompletionSource];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if (task.cancelled) {
-                [source cancel];
-            } else if (!task.error && !task.result) {
-                source.result = nil;
-            } else if (task.error) {
-                [source trySetError:task.error];
-            } else if (task.result) {
-                [self setLoginResultValues:@{}];
+        if (task.cancelled) {
+            [source cancel];
+        } else if (!task.error && !task.result) {
+            source.result = nil;
+        } else if (task.error) {
+            [source trySetError:task.error];
+        } else if (task.result) {
+            [self setLoginResultValues:nil];
 
-                [source trySetResult:task.result];
-            }
-        });
+            [source trySetResult:task.result];
+        }
         return source.task;
     }];
 }

--- a/ParseTwitterUtils/PF_Twitter.m
+++ b/ParseTwitterUtils/PF_Twitter.m
@@ -92,6 +92,30 @@
         return source.task;
     }];
 }
+- (BFTask *)deauthorizeInBackground {
+    if (self.consumerKey.length == 0 || self.consumerSecret.length == 0) {
+        //TODO: (nlutsenko) This doesn't look right, maybe we should add additional error code?
+        return [BFTask taskWithError:[NSError errorWithDomain:PFParseErrorDomain code:1 userInfo:nil]];
+    }
+
+    return [[self _performDeauthAsync] pftw_continueAsyncWithBlock:^id(BFTask *task) {
+        BFTaskCompletionSource *source = [BFTaskCompletionSource taskCompletionSource];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (task.cancelled) {
+                [source cancel];
+            } else if (!task.error && !task.result) {
+                source.result = nil;
+            } else if (task.error) {
+                [source trySetError:task.error];
+            } else if (task.result) {
+                [self setLoginResultValues:@{}];
+
+                [source trySetResult:task.result];
+            }
+        });
+        return source.task;
+    }];
+}
 
 - (void)authorizeWithSuccess:(void (^)(void))success
                      failure:(void (^)(NSError *error))failure
@@ -426,6 +450,26 @@
     }];
 
     return source.task;
+}
+
+- (BFTask *)_performDeauthAsync {
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
+    request.URL = [NSURL URLWithString:@"https://api.twitter.com/oauth2/invalidate_token"];
+    request.HTTPMethod = @"POST";
+
+    [self signRequest:request];
+
+    BFTaskCompletionSource *taskCompletionSource = [BFTaskCompletionSource taskCompletionSource];
+
+    [[self.urlSession dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        if (error) {
+            [taskCompletionSource trySetError:error];
+        } else {
+            [taskCompletionSource trySetResult:data];
+        }
+    }] resume];
+
+    return taskCompletionSource.task;
 }
 
 ///--------------------------------------

--- a/Tests/Unit/TwitterTests.m
+++ b/Tests/Unit/TwitterTests.m
@@ -673,6 +673,8 @@ typedef void (^NSURLSessionDataTaskCompletionHandler)(NSData *data, NSURLRespons
 
         XCTAssertNil(twitter.authToken);
         XCTAssertNil(twitter.authTokenSecret);
+        XCTAssertNil(twitter.userId);
+        XCTAssertNil(twitter.screenName);
 
         [expectation fulfill];
         return nil;

--- a/Tests/Unit/TwitterTests.m
+++ b/Tests/Unit/TwitterTests.m
@@ -633,7 +633,7 @@ typedef void (^NSURLSessionDataTaskCompletionHandler)(NSData *data, NSURLRespons
         NSError *error = task.error;
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.domain, PFParseErrorDomain);
-        XCTAssertEqual(error.code, 2);
+        XCTAssertEqual(error.code, 1);
         [expectation fulfill];
         return nil;
     }];
@@ -641,15 +641,12 @@ typedef void (^NSURLSessionDataTaskCompletionHandler)(NSData *data, NSURLRespons
 }
 
 - (void)testDeauthorizeLoggedInAccount {
-    id store = PFStrictClassMock([ACAccountStore class]);
-    NSURLSession *session = PFStrictClassMock([NSURLSession class]);
-
     id mockedStore = PFStrictClassMock([ACAccountStore class]);
     id mockedURLSession = PFStrictClassMock([NSURLSession class]);
     id mockedOperationQueue = PFStrictClassMock([NSOperationQueue class]);
 
     id mockedDialog = PFStrictProtocolMock(@protocol(PFOAuth1FlowDialogInterface));
-    PF_Twitter *twitter = [[PF_Twitter alloc] initWithAccountStore:store urlSession:session dialogClass:mockedDialog];
+    PF_Twitter *twitter = [[PF_Twitter alloc] initWithAccountStore:mockedStore urlSession:mockedURLSession dialogClass:mockedDialog];
     twitter.consumerKey = @"consumer_key";
     twitter.consumerSecret = @"consumer_secret";
     twitter.authToken = @"auth_token";
@@ -674,10 +671,8 @@ typedef void (^NSURLSessionDataTaskCompletionHandler)(NSData *data, NSURLRespons
         XCTAssertNil(error);
         XCTAssertNotNil(task.result);
 
-		XCTAssertNil(twitter.userId);
-		XCTAssertNil(twitter.screenName);
-		XCTAssertNil(twitter.userId);
-		XCTAssertNil(twitter.userId);
+        XCTAssertNil(twitter.authToken);
+        XCTAssertNil(twitter.authTokenSecret);
 
         [expectation fulfill];
         return nil;


### PR DESCRIPTION
There are two things going on here, in two separate commits:
1. On 16121e21f9f0b34555f4ef24183949d832e3983d, expose/document how `-[PFTwitter init]` works in that it is okay to call, and after setting `consumerKey` and `consumerSecret`, can be used to make Twitter API calls.
2. In 6e5e9ca6381f15428bfc579ce201143ab631b9b7, add support for deauthorization, by calling `oauth2/invalidate_token` on Twitter's API, and then to clear out local state on success.

6e5e9ca6381f15428bfc579ce201143ab631b9b7 contains tests for the newly added `deauthorizeInBackground` call, however, I wasn't able to get the tests to run locally, so, I can't promise that the tests do the right thing (after running `bundle install` locally, updating the deployment target, enabling ARC in the project and a few other steps that have slipped my mind, the rabbit hole seemed too deep to keep following).

Went to sign the CLA, and it told me `The 'Email' value has been registered on this form before. If you would like to update an existing contributor account, please email cla@fb.com with your details.`, so, I think thats all taken care of.
