### PR TITLE
Fix analyzer and build warnings.

### DIFF
--- a/ParseTwitterUtils/Internal/OAuthCore/PF_OAuthCore.m
+++ b/ParseTwitterUtils/Internal/OAuthCore/PF_OAuthCore.m
@@ -84,7 +84,9 @@ static NSData *PF_HMAC_SHA1(NSString *data, NSString *key) {
     // combine all parameters
     NSMutableDictionary *parameters = [oAuthAuthorizationParameters mutableCopy];
     [parameters addEntriesFromDictionary:additionalQueryParameters];
-    [parameters addEntriesFromDictionary:additionalBodyParameters];
+    if (additionalBodyParameters) {
+        [parameters addEntriesFromDictionary:additionalBodyParameters];
+    }
 
     NSArray *sortedKeys = [[parameters allKeys] sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
         return [obj1 compare:obj2] ?: [parameters[obj1] compare:parameters[obj2]];

--- a/Tests/Unit/TwitterTests.m
+++ b/Tests/Unit/TwitterTests.m
@@ -643,7 +643,6 @@ typedef void (^NSURLSessionDataTaskCompletionHandler)(NSData *data, NSURLRespons
 - (void)testDeauthorizeLoggedInAccount {
     id mockedStore = PFStrictClassMock([ACAccountStore class]);
     id mockedURLSession = PFStrictClassMock([NSURLSession class]);
-    id mockedOperationQueue = PFStrictClassMock([NSOperationQueue class]);
 
     id mockedDialog = PFStrictProtocolMock(@protocol(PFOAuth1FlowDialogInterface));
     PF_Twitter *twitter = [[PF_Twitter alloc] initWithAccountStore:mockedStore urlSession:mockedURLSession dialogClass:mockedDialog];


### PR DESCRIPTION
- Fixes unused method warning in tests
- Fixes misuse of nullability warning in PF_OAuthCore.

Depends on #31 
